### PR TITLE
added minor-only flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Or put it into your `package.json`:
 | --columns \<comma-separated-list-of-columns\> | Defines which columns should be shown in which order. (See [Available Columns](#available-columns) below) | `--columns name,current,latest,changes` |
 | --global | Check packages in the global install prefix instead of in the current project (equal to the npm outdated-option) | `--global` |
 | --depth \<number\> | Max depth for checking dependency tree (equal to the npm outdated-option) | `--depth 3` |
+| --minor-only | Check packages for updates in minor versions with fixed major version. | `--minor-only` |
 
 ### Available Columns
 

--- a/check-outdated.js
+++ b/check-outdated.js
@@ -309,6 +309,9 @@ const AVAILABLE_ARGUMENTS = {
 		}
 
 		return { depth };
+	},
+	'--minor-only': {
+		minorOnly: true
 	}
 };
 
@@ -398,7 +401,8 @@ function help (...additionalLines) {
 			'[--prefer-wanted]',
 			'[--columns <comma-separated-list-of-columns>]',
 			'[--global]',
-			'[--depth <number>]'
+			'[--depth <number>]',
+			'[--minor-only]'
 		].join(' '),
 		'',
 		'Arguments:',
@@ -439,6 +443,10 @@ function help (...additionalLines) {
 			[
 				'--depth <number>',
 				'Max depth for checking dependency tree (equal to the npm outdated-option).'
+			],
+			[
+				'--minor-only',
+				'Check packages for updates in minor versions with fixed major version.'
 			]
 		]),
 		...(Array.isArray(additionalLines) ? [''].concat(additionalLines) : []),
@@ -481,6 +489,14 @@ function getFilteredDependencies (dependencies, options) {
 
 	if (options.preferWanted) {
 		filteredDependencies = filteredDependencies.filter(({ current, wanted }) => current !== wanted);
+	}
+
+	if (options.minorOnly) {
+		filteredDependencies = filteredDependencies.filter(({ current, latest }) => {
+			const [currentMajor, currentMinor, currentPatch] = current.split(".");
+			const [latestMajor, latestMinor, latestPatch] = latest.split(".");
+			return currentMajor === latestMajor && currentMinor !== latestMinor;
+		});
 	}
 
 	return filteredDependencies;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"publish:patch": "npm version patch",
 		"preversion": "npm run lint && npm run test && npm run check-outdated",
 		"postversion": "git push && git push --tags && npm publish",
-		"check-outdated": "node check-outdated.js --ignore-pre-releases"
+		"check-outdated": "node check-outdated.js --ignore-pre-releases --minor-only"
 	},
 	"engines": {
 		"node": ">=10.0.0"

--- a/tests/index.js
+++ b/tests/index.js
@@ -441,7 +441,37 @@ void (async () => {
 		});
 	});
 
-	await describe('(Almost) all arguments (without "--prefer-wanted")', async () => {
+	await describe('--minor-only argument', async () => {
+		await test('should return with outdated dependency message', ['--minor-only'], mockData.defaultResponse, (command, exitCode, stdout) => {
+			expectVarToEqual(command, 'npm outdated --json --long --save false');
+			expectVarToEqual(exitCode, 1);
+
+			expectNoOfAffectedDependencies(stdout, mockData.defaultResponse, 35);
+
+			expect('`stdout` should contain the correct output', () => assert.equal(
+				stdout.replace(/\u0020+(\n|$)/gu, '$1'),
+				[
+					'3 outdated dependencies found:',
+					'',
+					'\u001B[4mPackage\u001B[24m             \u001B[4mCurrent\u001B[24m  \u001B[4mWanted\u001B[24m  \u001B[4mLatest\u001B[24m  \u001B[4mReference\u001B[24m         \u001B[4mChanges\u001B[24m                                           \u001B[4mLocation\u001B[24m',
+					'',
+					'\u001B[4mdependencies\u001B[24m',
+					'\u001B[33mmodule-diff-wanted\u001B[39m    1.\u001B[4m0\u001B[24m.0   \u001B[32m1\u001B[39m\u001B[32m.\u001B[39m\u001B[32;4m1\u001B[39;24m\u001B[32m.\u001B[39m\u001B[32m0\u001B[39m   \u001B[35m1\u001B[39m\u001B[35m.\u001B[39m\u001B[35;4m2\u001B[39;24m\u001B[35m.\u001B[39m\u001B[35m0\u001B[39m  \u001B[90m-\u001B[39m                 https://www.npmjs.com/package/module-diff-wanted  node_modules/module-diff-wanted',
+					'\u001B[33mmodule-minor\u001B[39m          1.\u001B[4m0\u001B[24m.0   \u001B[32m1\u001B[39m\u001B[32m.\u001B[39m\u001B[32m0\u001B[39m\u001B[32m.\u001B[39m\u001B[32m0\u001B[39m   \u001B[35m1\u001B[39m\u001B[35m.\u001B[39m\u001B[35;4m1\u001B[39;24m\u001B[35m.\u001B[39m\u001B[35m0\u001B[39m  package.json:4:5  https://www.npmjs.com/package/module-minor        node_modules/module-minor',
+					'module-revert         1.\u001B[4m1\u001B[24m.0   \u001B[32m1\u001B[39m\u001B[32m.\u001B[39m\u001B[32m1\u001B[39m\u001B[32m.\u001B[39m\u001B[32m0\u001B[39m   \u001B[35m1\u001B[39m\u001B[35m.\u001B[39m\u001B[35;4m0\u001B[39;24m\u001B[35m.\u001B[39m\u001B[35m0\u001B[39m  \u001B[90m-\u001B[39m                 https://www.npmjs.com/package/module-revert       node_modules/module-revert',
+					'',
+					'\u001B[4mColor legend\u001B[24m',
+					'\u001B[31mMajor update\u001B[39m: backward-incompatible updates',
+					'\u001B[33mMinor update\u001B[39m: backward-compatible features',
+					'\u001B[32mPatch update\u001B[39m: backward-compatible bug fixes',
+					'',
+					''
+				].join('\n')
+			));
+		});
+	});
+
+	await describe('(Almost) all arguments (without "--prefer-wanted" and "--minor-only")', async () => {
 		await test('should return with outdated dependency message if all options are activated', ['--ignore-pre-releases', '--ignore-dev-dependencies', '--ignore-packages', 'module-major,module-minor', '--global', '--depth', '10'], mockData.defaultResponse, (command, exitCode, stdout) => {
 			expectVarToEqual(command, 'npm outdated --json --long --save false --global --depth 10');
 			expectVarToEqual(exitCode, 1);


### PR DESCRIPTION
We added a flag that filters the result by which packages have an outdated minor version while disregarding any major version updates.

Examples:
0.2.0 -> 0.3.0: included
0.2.0 -> 1.3.0: excluded because major update
0.2.0 -> 0.2.1: excluded because no minor update