### PR TITLE
Add support for ignoring aliased NPM dependencies

### DIFF
--- a/check-outdated.js
+++ b/check-outdated.js
@@ -530,16 +530,20 @@ function getFilteredDependencies (dependencies, options) {
 		const packageVersionRegExp = /^(.+?)@(.*)$/u;
 
 		filteredDependencies = filteredDependencies.filter((dependency) => {
+			// Dependencies aliased to other dependencies with the package.json syntax '"alias-name": "npm:target-name@0.0.0"' are seen here as 'alias-name:target-name@0.0.0'.
+			// We therefore need to make sure in such cases to use the actual name 'alias-name', hence the split.
+			const actualDependencyName = dependency.name.split(":")[0];
+
 			for (const ignoredPackage of ignorePackages) {
 				const match = packageVersionRegExp.exec(ignoredPackage);
 
 				if (match === null) {
-					if (ignoredPackage === dependency.name) {
+					if (ignoredPackage === actualDependencyName) {
 						return false;
 					}
 				}
 				else {
-					if (match[1] === dependency.name) {
+					if (match[1] === actualDependencyName) {
 						if (semverInRange(getWantedOrLatest(dependency, options), match[2])) {
 							return false;
 						}


### PR DESCRIPTION
Hello! Thanks for your great library. I'm in the process of replacing anything using david to check-outdated and it works great so far.

I've seen a little problem however, if a package.json contains an aliased (renamed) dependency from NPM like:

```json
{
  "dependencies": {
     "alias-name": "npm:actual-library-name@1.0.0"
  }
}
```

Then this library is reported by `npm outdated` as `alias-name:actual-library-name@1.0.0`. No problem, I could ignore the library "alias-name:actual-library-name@1.0.0" in the CLI when calling check-outdated.

Issue is the `packageVersionRegExp` regex will match, and therefore the intended code `if (match === null) {` will never be ran.

The solution in such cases is to normalize the dependency name to its actual name, ie. the alias name, by splitting using the `:` delimiter. Since this is the only case (I know of) a dependency name can bear a `:` character, it won't break other types of dependency names and works with regular or SCM dependencies (as per my tests).

Thanks!

Valerian.